### PR TITLE
Configure `typos` to accept "als" as correct spelling

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+als = "als"


### PR DESCRIPTION
This will fix the CI failure noted [here](https://github.com/phiresky/ripgrep-all/pull/185#issuecomment-1733659151).